### PR TITLE
fix: remove unused imports in GeminiModal component

### DIFF
--- a/src/components/custom/GeminiModal.tsx
+++ b/src/components/custom/GeminiModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose, DialogDescription } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
 
 interface GeminiModalProps {
   isOpen: boolean;


### PR DESCRIPTION
This pull request includes a small change to `GeminiModal.tsx`. The change removes unused imports (`useState`, `useEffect`, and `Button`) to clean up the code.